### PR TITLE
Add GitHub Actions workflow for Android debug build

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -1,0 +1,44 @@
+name: Android CI - Debug APK
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+
+    - name: Cache Gradle
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build Debug APK
+      run: ./gradlew assembleDebug
+
+    - name: Upload Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-apk
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -2,9 +2,7 @@ name: Android CI - Debug APK
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -32,13 +30,14 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      run: chmod +x android/gradlew
 
     - name: Build Debug APK
+      working-directory: android
       run: ./gradlew assembleDebug
 
     - name: Upload Debug APK
       uses: actions/upload-artifact@v4
       with:
         name: debug-apk
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and uploads the Android debug APK on pushes, pull requests, and manual dispatches

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d65fe9456c833285700e5e67fd3bb4