### PR TITLE
Add binder display service interface for teleprompter

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,5 +40,9 @@
         <data android:scheme="g1ot"/>
       </intent-filter>
     </activity>
+    <service
+      android:name="io.texne.g1.basis.service.G1DisplayService"
+      android:exported="true"
+      android:enabled="true" />
   </application>
 </manifest>

--- a/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
+++ b/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/G1Glasses.aidl
@@ -1,0 +1,3 @@
+package io.texne.g1.basis.service.protocol;
+
+parcelable G1Glasses;

--- a/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/IG1DisplayService.aidl
+++ b/android/app/src/main/aidl/io/texne/g1/basis/service/protocol/IG1DisplayService.aidl
@@ -1,0 +1,23 @@
+package io.texne.g1.basis.service.protocol;
+
+import io.texne.g1.basis.service.protocol.G1Glasses;
+
+interface IG1DisplayService {
+    /** Send a new text to display / scroll */
+    void displayText(in String text);
+
+    /** Stop / clear the current display */
+    void stopDisplay();
+
+    /** Pause the current display without clearing */
+    void pauseDisplay();
+
+    /** Resume a paused display */
+    void resumeDisplay();
+
+    /** Adjust the scroll speed for the display */
+    void setScrollSpeed(float speed);
+
+    /** Get status about the glasses / display */
+    G1Glasses getGlassesInfo();
+}

--- a/android/app/src/main/java/com/teleprompter/MainActivity.kt
+++ b/android/app/src/main/java/com/teleprompter/MainActivity.kt
@@ -1,8 +1,14 @@
 package com.teleprompter
 import expo.modules.splashscreen.SplashScreenManager
 
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
 import android.os.Build
 import android.os.Bundle
+import android.os.IBinder
+import android.util.Log
 
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
@@ -10,8 +16,31 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnable
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 import expo.modules.ReactActivityDelegateWrapper
+import io.texne.g1.basis.service.G1DisplayService
+import io.texne.g1.basis.service.protocol.IG1DisplayService
 
 class MainActivity : ReactActivity() {
+  private var displayService: IG1DisplayService? = null
+  private var isServiceBound: Boolean = false
+
+  private val displayServiceConnection = object : ServiceConnection {
+    override fun onServiceConnected(name: ComponentName, binder: IBinder) {
+      displayService = IG1DisplayService.Stub.asInterface(binder)
+      isServiceBound = true
+      Log.d(TAG, "Display service connected")
+      displayService?.apply {
+        setScrollSpeed(1.0f)
+        displayText("Hello world")
+      }
+    }
+
+    override fun onServiceDisconnected(name: ComponentName) {
+      displayService = null
+      isServiceBound = false
+      Log.d(TAG, "Display service disconnected")
+    }
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     // Set the theme to AppTheme BEFORE onCreate to support
     // coloring the background, status bar, and navigation bar.
@@ -21,6 +50,10 @@ class MainActivity : ReactActivity() {
     SplashScreenManager.registerOnActivity(this)
     // @generated end expo-splashscreen
     super.onCreate(null)
+
+    Intent(this, G1DisplayService::class.java).also {
+      bindService(it, displayServiceConnection, Context.BIND_AUTO_CREATE)
+    }
   }
 
   /**
@@ -61,5 +94,23 @@ class MainActivity : ReactActivity() {
       // Use the default back button implementation on Android S
       // because it's doing more than [Activity.moveTaskToBack] in fact.
       super.invokeDefaultOnBackPressed()
+  }
+
+  override fun onDestroy() {
+      if (isServiceBound) {
+          try {
+              displayService?.stopDisplay()
+              unbindService(displayServiceConnection)
+          } catch (throwable: IllegalArgumentException) {
+              Log.w(TAG, "Attempted to unbind display service that was not bound", throwable)
+          }
+          isServiceBound = false
+      }
+      displayService = null
+      super.onDestroy()
+  }
+
+  companion object {
+      private const val TAG = "MainActivity"
   }
 }

--- a/android/app/src/main/java/io/texne/g1/basis/service/G1DisplayService.kt
+++ b/android/app/src/main/java/io/texne/g1/basis/service/G1DisplayService.kt
@@ -1,0 +1,141 @@
+package io.texne.g1.basis.service
+
+import android.app.Service
+import android.content.Intent
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import io.texne.g1.basis.service.protocol.G1Glasses
+import io.texne.g1.basis.service.protocol.IG1DisplayService
+
+/**
+ * Binder backed service that accepts teleprompter text commands from external clients
+ * and updates the in-app renderer state.
+ */
+class G1DisplayService : Service() {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val stateLock = Any()
+
+    // Simulated state - in a real implementation these would be wired to the actual glass device.
+    private var currentId: String = ""
+    private var currentName: String = "G1 Glasses"
+    private var currentState: Int = G1Glasses.STATE_DISCONNECTED
+    private var battery: Int = 100
+    private var currentText: String = ""
+    private var scrollSpeed: Float = G1Glasses.DEFAULT_SCROLL_SPEED
+    private var isPaused: Boolean = false
+
+    private val binder = G1DisplayServiceImpl()
+
+    override fun onCreate() {
+        super.onCreate()
+        synchronized(stateLock) {
+            currentId = "G1-${System.currentTimeMillis()}"
+            currentState = G1Glasses.STATE_CONNECTED
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        mainHandler.post { stopScrollingInternal(clearText = true) }
+        return super.onUnbind(intent)
+    }
+
+    private inner class G1DisplayServiceImpl : IG1DisplayService.Stub() {
+        override fun displayText(text: String) {
+            val safeText = text.ifEmpty { "" }
+            mainHandler.post {
+                synchronized(stateLock) {
+                    currentText = safeText
+                    isPaused = false
+                    currentState = if (safeText.isEmpty()) {
+                        G1Glasses.STATE_CONNECTED
+                    } else {
+                        G1Glasses.STATE_DISPLAYING
+                    }
+                }
+                Log.d(TAG, "displayText invoked with ${safeText.length} characters")
+                // TODO: Hook into actual UI rendering once the teleprompter view is available.
+            }
+        }
+
+        override fun stopDisplay() {
+            mainHandler.post {
+                stopScrollingInternal(clearText = true)
+                Log.d(TAG, "stopDisplay invoked")
+            }
+        }
+
+        override fun pauseDisplay() {
+            mainHandler.post {
+                synchronized(stateLock) {
+                    if (currentText.isNotEmpty()) {
+                        isPaused = true
+                        currentState = G1Glasses.STATE_PAUSED
+                    }
+                }
+                Log.d(TAG, "pauseDisplay invoked")
+            }
+        }
+
+        override fun resumeDisplay() {
+            mainHandler.post {
+                synchronized(stateLock) {
+                    if (currentText.isNotEmpty()) {
+                        isPaused = false
+                        currentState = G1Glasses.STATE_DISPLAYING
+                    }
+                }
+                Log.d(TAG, "resumeDisplay invoked")
+            }
+        }
+
+        override fun setScrollSpeed(speed: Float) {
+            val sanitized = if (speed.isNaN() || speed <= 0f) {
+                G1Glasses.DEFAULT_SCROLL_SPEED
+            } else {
+                speed
+            }
+            mainHandler.post {
+                synchronized(stateLock) {
+                    scrollSpeed = sanitized
+                }
+                Log.d(TAG, "setScrollSpeed invoked with $sanitized")
+            }
+        }
+
+        override fun getGlassesInfo(): G1Glasses {
+            val snapshot = synchronized(stateLock) {
+                G1Glasses().apply {
+                    id = currentId
+                    name = currentName
+                    connectionState = currentState
+                    batteryPercentage = battery
+                    isDisplaying = currentState == G1Glasses.STATE_DISPLAYING
+                    isPaused = this@G1DisplayService.isPaused
+                    scrollSpeed = this@G1DisplayService.scrollSpeed
+                    currentText = this@G1DisplayService.currentText
+                }
+            }
+            Log.d(TAG, "getGlassesInfo invoked")
+            return snapshot
+        }
+    }
+
+    private fun stopScrollingInternal(clearText: Boolean) {
+        synchronized(stateLock) {
+            isPaused = false
+            currentState = G1Glasses.STATE_CONNECTED
+            if (clearText) {
+                currentText = ""
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "G1DisplayService"
+    }
+}

--- a/android/app/src/main/java/io/texne/g1/basis/service/protocol/G1Glasses.kt
+++ b/android/app/src/main/java/io/texne/g1/basis/service/protocol/G1Glasses.kt
@@ -1,0 +1,55 @@
+package io.texne.g1.basis.service.protocol
+
+import android.os.Parcel
+import android.os.Parcelable
+
+/**
+ * Parcelable representation of the glasses state that can be shared over binder.
+ */
+class G1Glasses() : Parcelable {
+    var id: String = ""
+    var name: String = ""
+    var connectionState: Int = STATE_DISCONNECTED
+    var batteryPercentage: Int = 0
+    var isDisplaying: Boolean = false
+    var isPaused: Boolean = false
+    var scrollSpeed: Float = DEFAULT_SCROLL_SPEED
+    var currentText: String = ""
+
+    private constructor(parcel: Parcel) : this() {
+        id = parcel.readString().orEmpty()
+        name = parcel.readString().orEmpty()
+        connectionState = parcel.readInt()
+        batteryPercentage = parcel.readInt()
+        isDisplaying = parcel.readByte() != 0.toByte()
+        isPaused = parcel.readByte() != 0.toByte()
+        scrollSpeed = parcel.readFloat()
+        currentText = parcel.readString().orEmpty()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(id)
+        parcel.writeString(name)
+        parcel.writeInt(connectionState)
+        parcel.writeInt(batteryPercentage)
+        parcel.writeByte(if (isDisplaying) 1 else 0)
+        parcel.writeByte(if (isPaused) 1 else 0)
+        parcel.writeFloat(scrollSpeed)
+        parcel.writeString(currentText)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<G1Glasses> {
+        const val STATE_DISCONNECTED = 0
+        const val STATE_CONNECTED = 1
+        const val STATE_DISPLAYING = 2
+        const val STATE_PAUSED = 3
+
+        const val DEFAULT_SCROLL_SPEED = 1.0f
+
+        override fun createFromParcel(parcel: Parcel): G1Glasses = G1Glasses(parcel)
+
+        override fun newArray(size: Int): Array<G1Glasses?> = arrayOfNulls(size)
+    }
+}


### PR DESCRIPTION
## Summary
- add IG1DisplayService AIDL contract to send scrolling text, pause/resume, and query state
- implement G1DisplayService binder that updates teleprompter state on the main thread and returns G1Glasses details
- bind the UI activity to the new service, register it in the manifest, and expose a Parcelable G1Glasses state object

## Testing
- ./gradlew :app:assembleDebug --console=plain *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8af8a5f788332a0113e35773f49fc